### PR TITLE
use eth_requestAccounts instead of deprecated eth_accounts 

### DIFF
--- a/src/redux/blockchain/blockchainActions.js
+++ b/src/redux/blockchain/blockchainActions.js
@@ -38,7 +38,7 @@ export const connect = () => {
       let web3 = new Web3(window.ethereum);
       try {
         const accounts = await window.ethereum.request({
-          method: "eth_accounts",
+          method: "eth_requestAccounts",
         });
         const networkId = await window.ethereum.request({
           method: "net_version",


### PR DESCRIPTION
Connect to wallet function doesn't work as it's using a wrong the wrong `ethereum.request({ method: 'eth_accounts' }); `function.
Instead, use `ethereum.request({ method: 'eth_requestAccounts' }); `for it to work